### PR TITLE
chore: rename lng to lon

### DIFF
--- a/src/api/nearest.js
+++ b/src/api/nearest.js
@@ -25,13 +25,13 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 router.get("/", async function (req, res, next) {
   try{
-    let { zoom_level, lng, lat } = req.query;
+    let { zoom_level, lon, lat } = req.query;
     zoom_level = parseInt(zoom_level);
-    lng = parseFloat(lng);
+    lon = parseFloat(lon);
     lat = parseFloat(lat);
-    console.log("lng:", lng);
+    console.log("lon:", lon);
     chai.expect(zoom_level).above(0);
-    chai.expect(lng).not.NaN;
+    chai.expect(lon).not.NaN;
     chai.expect(lat).not.NaN;
     let query;
     if (zoom_level <= 11) {
@@ -45,7 +45,7 @@ router.get("/", async function (req, res, next) {
       zoom_level = ${zoom_level}
     ORDER BY
       active_tree_region.centroid <->
-      ST_SetSRID(ST_MakePoint(${lng}, ${lat}),4326)
+      ST_SetSRID(ST_MakePoint(${lon}, ${lat}),4326)
     LIMIT 1;
     `,
         values: [],
@@ -59,7 +59,7 @@ router.get("/", async function (req, res, next) {
     clusters
   ORDER BY
     location <->
-    ST_SetSRID(ST_MakePoint(${lng}, ${lat}),4326)
+    ST_SetSRID(ST_MakePoint(${lon}, ${lat}),4326)
   LIMIT 1;
     `,
         values: [],
@@ -75,7 +75,7 @@ router.get("/", async function (req, res, next) {
     active = true
   ORDER BY
     estimated_geometric_location <->
-    ST_SetSRID(ST_MakePoint(${lng}, ${lat}),4326)
+    ST_SetSRID(ST_MakePoint(${lon}, ${lat}),4326)
   LIMIT 1;
     `,
         values: [],

--- a/src/api/nearest.test.js
+++ b/src/api/nearest.test.js
@@ -26,10 +26,10 @@ describe("nearest", () => {
     jest.clearAllMocks();
   });
 
-  it("/nearest?zoom_level=16&lng=85.5&lat=23.4", async () => {
+  it("/nearest?zoom_level=16&lon=85.5&lat=23.4", async () => {
     query.mockResolvedValue({ rows: nearestResult });
     const response = await request(app).get(
-      "/nearest?zoom_level=16&lng=85.5&lat=23.4"
+      "/nearest?zoom_level=16&lon=85.5&lat=23.4"
     );
     expect(new Pool().query).toBeDefined();
     expect(response.statusCode).toBe(200);
@@ -42,10 +42,10 @@ describe("nearest", () => {
     });
   });
 
-  it("/nearest?zoom_level=14&lng=85.5&lat=23.4", async () => {
+  it("/nearest?zoom_level=14&lon=85.5&lat=23.4", async () => {
     query.mockResolvedValue({ rows: nearestResult });
     const response = await request(app).get(
-      "/nearest?zoom_level=14&lng=85.5&lat=23.4"
+      "/nearest?zoom_level=14&lon=85.5&lat=23.4"
     );
     expect(new Pool().query).toBeDefined();
     expect(response.statusCode).toBe(200);
@@ -58,10 +58,10 @@ describe("nearest", () => {
     });
   });
 
-  it("/nearest?zoom_level=8&lng=85.5&lat=23.4", async () => {
+  it("/nearest?zoom_level=8&lon=85.5&lat=23.4", async () => {
     query.mockResolvedValue({ rows: nearestResult });
     const response = await request(app).get(
-      "/nearest?zoom_level=8&lng=85.5&lat=23.4"
+      "/nearest?zoom_level=8&lon=85.5&lat=23.4"
     );
     expect(new Pool().query).toBeDefined();
     expect(response.statusCode).toBe(200);


### PR DESCRIPTION
# Description
- rename `lng` to `lon`

Fixing consistency issue across the project https://github.com/Greenstand/treetracker-web-map-core/pull/133